### PR TITLE
fix: bundesbank url doesn't work with http anymore, updated to https

### DIFF
--- a/classes/dataBackend/file/FileDataBackend.php
+++ b/classes/dataBackend/file/FileDataBackend.php
@@ -18,7 +18,7 @@ class FileDataBackend extends DataBackend
 {
     
     // @codingStandardsIgnoreStart
-    const DOWNLOAD_URI = "http://www.bundesbank.de/Redaktion/DE/Standardartikel/Aufgaben/Unbarer_Zahlungsverkehr/bankleitzahlen_download.html";
+    const DOWNLOAD_URI = "https://www.bundesbank.de/Redaktion/DE/Standardartikel/Aufgaben/Unbarer_Zahlungsverkehr/bankleitzahlen_download.html";
     // @codingStandardsIgnoreEnd
 
     /**


### PR DESCRIPTION
When auto-updating the bundesbank file an error was thrown:  
`PHP Fatal error:  Uncaught malkusch\\bav\\DataBackendIOException: Failed to download 'http://www.bundesbank.de/Redaktion/DE/Standardartikel/Aufgaben/Unbarer_Zahlungsverkehr/bankleitzahlen_download.html'. in /var/www/iban-test/vendor/malkusch/bav/classes/dataBackend/file/download/Downloader.php:73\nStack trace:\n#0 /var/www/iban-test/vendor/malkusch/bav/classes/dataBackend/file/FileDataBackend.php(162): malkusch\\bav\\Downloader->downloadContent('http://www.bund...')\n#1 /var/www/iban-test/vendor/malkusch/bav/classes/dataBackend/update/AutomaticUpdatePlan.php(49): malkusch\\bav\\FileDataBackend->update()\n#2 [internal function]: malkusch\\bav\\AutomaticUpdatePlan->malkusch\\bav\\{closure}()\n#3 /var/www/iban-test/vendor/malkusch/bav/classes/util/Lock.php(88): call_user_func(Object(Closure))\n#4 /var/www/iban-test/vendor/malkusch/bav/classes/dataBackend/update/AutomaticUpdatePlan.php(54): malkusch\\bav\\Lock->nonblockingExecuteOnce(Object(Closure))\n#5 /var/www/iban-test/vendor/malkusch/bav/classes/dataBackend/DataBackendContainer.php(72): malkusc in /var/www/iban-test/vendor/malkusch/bav/classes/dataBackend/file/download/Downloader.php on line 73`

The (old) http://-URL of the bundesbank redirects to https:// which cURL somehow didn't follow when downloading the bankleitzahlen-file. In order to fix that I changed the bundesbank's URL to https://.